### PR TITLE
Changed the terminal CursorLine background color

### DIFF
--- a/colors/distinguished.vim
+++ b/colors/distinguished.vim
@@ -43,7 +43,7 @@ call s:ColorDictParser({
 	\ , 'Cursor'                      : [     '',     '',               '',      'ffffff',  'dd4010',               '']
 	\ , 'lCursor'                     : [     '',     '',               '',      'ffffff',  '89b6e2',               '']
 	\
-	\ , 'CursorLine'                  : [     16,    231,               '',            '',  '3a3a3a',               '']
+	\ , 'CursorLine'                  : [     '',    234,               '',            '',  '3a3a3a',               '']
 	\ , 'CursorColumn'                : [    231,    237,               '',      'ffffff',  '3a3a3a',               '']
 	\
 	\ , 'Folded'                      : [    249,    234,               '',      'b2b2b2',  '1c1c1c',               '']


### PR DESCRIPTION
It now better matches the (prettier) color in gvim/macvim.
